### PR TITLE
Fix editing master resetting metadata

### DIFF
--- a/src/pages/MasterEditPage.vue
+++ b/src/pages/MasterEditPage.vue
@@ -14,6 +14,8 @@ const isEditing = reactive({ value: false })
 const masterForm = reactive({
   title: '',
   checklistItems: [] as ChecklistItem[],
+  createdAt: 0,
+  usageCount: 0,
 })
 
 const id = route.params.id as string | undefined
@@ -25,11 +27,14 @@ onMounted(async () => {
     const existing = await db.get('checklist_masters', id)
     if (existing) {
       masterForm.title = existing.title
+      masterForm.createdAt = existing.createdAt
+      masterForm.usageCount = existing.usageCount
       const items = await db.getAllFromIndex('checklist_items', 'checklistMasterId', id)
       console.log(items)
       // チェックリスト項目をインデックス順に並べる
       masterForm.checklistItems = items.sort((a, b) => a.index - b.index)
     } else {
+      isEditing.value = false
       alert('指定されたテンプレートが見つかりませんでした。')
       router.push('/masters')
     }
@@ -44,9 +49,9 @@ const saveMasterAndItems = async () => {
   const master: ChecklistMaster = {
     id: newId,
     title: masterForm.title.trim(),
-    createdAt: now,
+    createdAt: isEditing.value ? masterForm.createdAt : now,
     updatedAt: now,
-    usageCount: 0,
+    usageCount: isEditing.value ? masterForm.usageCount : 0,
   }
 
   await db.put('checklist_masters', master)


### PR DESCRIPTION
## Summary
- keep `createdAt` and `usageCount` when editing checklist master
- treat invalid edit URLs as new templates

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843b90cf004832f80efe723b1a466eb