### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
       - id: deploy
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,28 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test -- --run
+
+  deploy-pages:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./dist
+      - id: deploy
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ Build the production bundle with:
 ```bash
 npm run build
 ```
+
+The site is automatically deployed to **GitHub Pages** from the `main` branch.
+You can access the latest version at:
+
+```
+https://<your-github-username>.github.io/check-list-app/
+```

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -55,7 +55,7 @@ const routes: RouteRecordRaw[] = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/check-list-app/',
   plugins: [vue()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- configure Vite to deploy to GitHub Pages
- update router history base to support non-root deploys
- add GitHub Actions job to build and deploy to Pages
- document the Pages site URL in README

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_684412d86e80832f827dc2605fdb2a58